### PR TITLE
Fix test imports and helper usage

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,8 @@
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
+# Add the src directory to the import path so that the modules package can be
+# imported when running the tests directly from the repository root.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
 import modules.calculate_metrics as calculate_metrics
 
@@ -8,8 +10,8 @@ def test_cyclomatic_complexity():
     """
     Test the cyclomatic complexity metric on a sample C source file.
     """
-    sourceCode = os.path.join(os.getcwd(), "tests", "src", "cyclomatic_Complexity.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_cyclomatic_complexity)
+    sourceCode = os.path.join(os.getcwd(), "tests", "src", "cyclomatic_complexity.c")
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_cyclomatic_complexity)
     trueRestult = [2, 2, 3, 4, 3, 4, 4, 4, 8]
     
     for i in range(len(testResult)):
@@ -20,7 +22,7 @@ def test_number_of_loops():
     Test the number of loops metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "number_of_loops.cpp")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_loops)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_loops)
     trueResult = [0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3]
     
     for i in range(len(testResult)):
@@ -31,7 +33,7 @@ def test_number_nested_loops():
     Test the number of nested loops metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "number_of_nested_loops.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_nested_loops)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_nested_loops)
     trueResult = [0, 0, 1, 1, 1, 1, 1, 3, 2]
     
     for i in range(len(testResult)):
@@ -42,7 +44,7 @@ def test_max_loop_nesting_level():
     Test the maximum loop nesting level metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "max_loop_nesting_level.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_max_nesting_loop_depth)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_max_nesting_loop_depth)
     trueResult = [0, 1, 2, 3, 3, 2, 2, 3, 13]
     
     for i in range(len(testResult)):
@@ -53,7 +55,7 @@ def test_number_of_parameter_variables():
     Test the number of parameter variables metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "number_of_parameter_variables.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_parameter_variables)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_parameter_variables)
     trueResult = [0, 1, 2, 3, 4]
     
     for i in range(len(testResult)):
@@ -64,7 +66,7 @@ def test_number_of_variables_as_callee_parameters():
     Test the number of variables as callee parameters metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "number_of_variables_as_callee_parameters.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_callee_parameter_variables)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_callee_parameter_variables)
     trueResult = [0, 1, 2, 0, 0, 1, 2, 1, 4, 2, 5, 1]
     
     for i in range(len(testResult)):
@@ -75,7 +77,7 @@ def test_number_of_pointer_arithmetic_ops():
     Test the number of pointer arithmetic operations metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "number_of_pointer_arithmetic_operations.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_pointer_arithmetic)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_pointer_arithmetic)
     #print(testResult)
     trueResult = [3, 2, 2, 2, 2, 0, 1, 1, 2, 2]
 
@@ -88,7 +90,7 @@ def test_number_of_variables_involved_in_pointer_arithmetic():
     Test the number of variables involved in pointer arithmetic metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "number_of_variables_involved_in_pointer_arithmetic.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_variables_involved_in_pointer_arithmetic)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_variables_involved_in_pointer_arithmetic)
     trueResult = [1, 2, 3, 1, 2, 3, 2, 1, 1, 1, 3]
     
     for i in range(len(testResult)):
@@ -99,7 +101,7 @@ def test_max_pointer_arithmetic_variables_is_involved_in():
     Test the maximum pointer arithmetic variables involved in metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "max_pointer_arithmetic_variable_is_involved.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_max_pointer_arithmetic_variable_is_involved_in)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_max_pointer_arithmetic_variable_is_involved_in)
     trueResult = [1, 2, 1, 1, 2, 1, 2, 2, 3]
     
     for i in range(len(testResult)):
@@ -110,7 +112,7 @@ def test_calculate_number_of_nested_control_structures():
     Test the number of nested control structures metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "controll_structures.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_nested_control_structures)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_nested_control_structures)
     trueResult = [0, 0, 0, 0, 0, 0, 1, 1, 2]
     
     for i in range(len(testResult)):
@@ -121,7 +123,7 @@ def test_calculate_maximum_nesting_level_of_control_structures():
     Test the maximum nesting level of control structures metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "controll_structures.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_maximum_nesting_level_of_control_structures)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_maximum_nesting_level_of_control_structures)
     trueResult = [0, 1, 1, 1, 1, 1, 2, 3, 4]
     
     for i in range(len(testResult)):
@@ -132,7 +134,7 @@ def test_calculate_maximum_of_control_dependent_control_structures():
     Test the maximum of control dependent control structures metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "control_dependent_control_structures.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_maximum_of_control_dependent_control_structures)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_maximum_of_control_dependent_control_structures)
     trueResult = [0, 1, 2, 4, 5, 9, 3]
     
     for i in range(len(testResult)):
@@ -143,7 +145,7 @@ def test_calculate_maximum_of_data_dependent_control_structures():
     Test the maximum of data dependent control structures metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "data_dependent_control_structures.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_maximum_of_data_dependent_control_structures)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_maximum_of_data_dependent_control_structures)
     trueResult = [0, 1, 3, 6]
     
     for i in range(len(testResult)):
@@ -154,7 +156,7 @@ def test_calculate_number_if_structures_without_else():
     Test the number of if structures without else metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "if_structures_without_else.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_if_structures_without_else)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_if_structures_without_else)
     trueResult = [1, 1, 0, 2, 2, 4]
     
     for i in range(len(testResult)):
@@ -165,7 +167,7 @@ def test_number_of_variables_involved_in_control_predicates():
     Test the number of variables involved in control predicates metric on a sample C source file.
     """
     sourceCode = os.path.join(os.getcwd(), "tests", "src", "number_of_variables_involved_in_control_predicates.c")
-    testResult = calculate_metrics.runTest(sourceCode, calculate_metrics.calculate_number_of_variables_involved_in_control_predicates)
+    testResult = calculate_metrics.run_test(sourceCode, calculate_metrics.calculate_number_of_variables_involved_in_control_predicates)
     trueResult = [1, 2, 3, 4, 3, 4, 2, 4]
     
     for i in range(len(testResult)):


### PR DESCRIPTION
## Summary
- fix `sys.path` in tests so modules can be imported
- call correct `run_test` helper
- fix cyclomatic complexity test file name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ujson')*

------
https://chatgpt.com/codex/tasks/task_e_6873ab7d878c8322a731e9ce189e76a2